### PR TITLE
Added parameter for subscribe a user in "pending" status

### DIFF
--- a/mailupy/client.py
+++ b/mailupy/client.py
@@ -495,7 +495,7 @@ class Mailupy:
         )
         return resp.json()
 
-    def subscribe_to_list(self, list_id, recipient_name, recipient_email, fields={}):
+    def subscribe_to_list(self, list_id, recipient_name, recipient_email, pending=False, fields={}):
         """
         Subscribe recipient to a list.
 
@@ -514,14 +514,18 @@ class Mailupy:
         :return: Recipient ID
         :rtype: int
         """
+        query_parameters = ""
         payload = json.dumps({
             "Name": recipient_name,
             "Email": recipient_email,
             "Fields": self._build_mailup_fields(fields)
         })
+        if pending:
+            query_parameters = "ConfirmEmail=True"
+
         resp = self._requests_wrapper(
             'POST',
-            self._build_url(f'/List/{list_id}/Recipient'),
+            self._build_url(f'/List/{list_id}/Recipient', query_parameters=query_parameters),
             headers=self._default_headers(),
             data=payload
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,6 +53,11 @@ class TestClient(unittest.TestCase):
         assert m.subscribe_to_list(1, 'ASDFGHJKL', 'email@email.email') == 16
 
     @patch('mailupy.Mailupy._requests_wrapper', side_effect=mock_request)
+    def test_subscribe_to_list_pending(self, func):
+        m = Mailupy('username', 'password', 'client-id', 'client-secret')
+        assert m.subscribe_to_list(1, 'ASDFGHJKL', 'email@email.email', pending=True) == 16
+
+    @patch('mailupy.Mailupy._requests_wrapper', side_effect=mock_request)
     def test_subscribe_to_group(self, func):
         m = Mailupy('username', 'password', 'client-id', 'client-secret')
         assert m.subscribe_to_group(6, 'ASDFGHJKL', 'email@email.email', {'test': 'test'}) == 18


### PR DESCRIPTION
As per Mailup documentation a unsubscribed user can't be subscribed again without Confirmed Opt-In:

http://help.mailup.com/display/mailupapi/Recipients#Recipients-Updatesubscriptionstatusofarecipient

To activate Confirmed Opt-In you must pass "ConfirmEmail=True" as querystring to the subscribe to list endpoint.

With this PR we can easily do something like this:

```
confirmed_opt_in=False
user = client.get_recipient_from_list(settings.MAIULP_LIST_ID, "test@test.it)
if user:
  if user["Status"] == "OPTIN":
    return "Email already registered"
  elif user["Status"] == "OPTOUT":
    confirmed_opt_in=True
client.subscribe_to_list(settings.MAIULP_LIST_ID, "Test test". "test@test.it", pending=confirmet_opt_in)
```

This way we can cover the case in object: re-subscribing a user who's unsubscribed.
