### PR TITLE
KeyError on invalid credentials + 'get_fields' misses one page

### DIFF
--- a/mailupy/client.py
+++ b/mailupy/client.py
@@ -55,6 +55,8 @@ class Mailupy:
                 headers=self._default_headers()
             ).json()
             total = data['TotalElementsCount'] // data['PageSize']
+            if data['TotalElementsCount'] % data['PageSize'] :
+                total += 1
             is_paginated = data['IsPaginated']
             for item in data['Items']:
                 yield item

--- a/mailupy/exceptions.py
+++ b/mailupy/exceptions.py
@@ -14,6 +14,8 @@ class MailupyRequestException(MailupyException):
     It's raised whenever the library receive a response with a status code greater than or equal to 400.
     """
     def __init__(self, response):
+        try : err = response.json()['ErrorDescription']
+        except KeyError : err = response.json()['error_description']
         super(MailupyException, self).__init__(
-            f"Error {response.status_code} - {response.json()['ErrorDescription']}"
+            f"Error {response.status_code} - {err}"
         )


### PR DESCRIPTION
PROBLEM 1

I'm getting a KeyError on invalid credentials.
It works if looking for 'error_description' key instead.
Maybe 'ErrorDescription' is an old key or returned on other kind of errors.

PROBLEM 2

I have and expect 27 fields when calling 'get_fields'.
I get only 20 items (just the first page).
